### PR TITLE
Switch to github action for publishing.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,46 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: main
+
+name: Quarto Publish
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      # - name: Install Quarto Extensions
+      #   run: |
+      #     quarto install --no-prompt extension <github-user>/<repo-name>
+
+      # - name: Install Python and Dependencies
+      #   uses: actions/setup-python@v4.3.0
+      #   with:
+      #     python-version: '3.10'
+      #     cache: 'pip'
+      # - run: pip install -r requirements.txt
+
+      # - name: Install R
+      #   uses: r-lib/actions/setup-r@v2
+      #   with:
+      #     r-version: '4.2.0'
+
+      # - name: Install R Dependencies
+      #   uses: r-lib/actions/setup-renv@v2
+      #   with:
+      #     cache-version: 1
+
+      - name: Render and Publish
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,10 @@
 .RData
 .Ruserdata
 
+# Quarto files
 /.quarto/
+/_site/
+
+# Emacs temporary files
+\#*
+*~

--- a/README.md
+++ b/README.md
@@ -1,21 +1,47 @@
 # Contributing to this Blog
 
-**IMPORTANT:** Please only pull request this repository if you have already been invited or approved by the data.table community team.  
+**IMPORTANT:** Please only pull request this repository if you have already been invited or approved by the data.table community team.
 If you would like to propose a guest blog post, email r.data.table@gmail.com and we will get back to you shortly.
 
 1. Fork this repository.
 
-2. In the `posts` directory, find the folder corresponding to your anticipated blog post.
-It will be named in the form `YYYY-MM-DD-post_title-author_name`, where the date is the anticipated date of publication, the title is an abbreviated version of your topic, and the name is yours.
+2. In the `posts` directory, copy the a folder corresponding to your anticipated blog post. It should use the form
+   `YYYY-MM-DD-post_title-author_name`, where the date is the anticipated date of publication, the title is an
+   abbreviated version of your topic, and the name is yours.
 
-3. Open `index.qmd`.  **Do not rename this file!**
+3. Copy the `posts/2023-10-02-post-template/index.qmd` into your newly created directory.  **Do not rename this file!**
 
-4. In the YAML, **change only the `title` and `author` fields**, if you wish to tweak them.
+4. Open your new `YYYY-MM-DD-post_title-author_name/index.qmd` that you have just copied and edit the header. You should
+   change the `title`, `date` and `author` fields. If you wish to add a picture to the post add it to the directory and rename
+   it `ìmage.jpg`.
+
+```yaml
+---
+title: "Guest Post on The Raft"
+author: "A.N.Other"
+date: "2023-10-18"
+categories: [news, code, analysis]
+image: "image.jpg"
+draft: true
+---
+```
 
 5. In the body of `index.qmd`, compose your blog post.
 
-6. (Optional) Choose an image for your blog's header.  Replace `image.jpg` with your image.  If you do not wish to choose an image, we will be happy to select one for you.
+```` markdown
+This is a post with executable code.
 
-7. Render your document only (not the full quarto project) to preview it.
+```{r}
+1 + 1
+```
 
-8. When you are finished, pull request this repository with your finished post.
+````
+
+6. Render your document only (not the full quarto project) to preview it.
+
+7. When you are finished, stage, commit and push your `index.qmd` and `image.jpg` only, do **NOT** include any of the
+   built files (they should be ignored by git automatically though).
+
+8. Your fork on GitHub will now be ahead of the `rdatatable-community/The-Raft` from which you've branched and you
+   should see the option to `Contribute`. Doing so will create a Pull Request, once merged the post will be published in
+   due course.


### PR DESCRIPTION
This adds a `.github/workflows/publish.yaml` for publishing pushes to the `main` branch automatically.

For this to work though I think you need to run `quarto publish` locally first, selecting `GitHub Pages` and letting it create and push the `gh-pages` branch. The settings on GitHub then need changing, there are two possible places that you need to check...

1. _Settings > Actions > General > Workflow permissions_ should have _Read and write permissions_ selected. This allows the workflow to read from the `main` branch and write to `gh-pages` branch.
2. _Settings > Pages_ probably need changing the _Source_ should be _Deploy from a branch_ and the _Branch_ should be `gh-pages` and the directory should be `/ (root)`.

I've added the `/_site/` directory to `.gitignore` (along with ignoring temporary files my IDE creates) and updated the `README.md` to reflect the process of making submissions (it looks like at you request posts as draft and then publish them in due course perhaps).

It might be worth instigating a branch protection rule on the `main` branch to require a Pull Request on `main` (under _Settings > branch_).

Completely understand that you don't want to break the site and if you'd rather not include this, but also happy to help work through the transition if you would like to and if this PR doesn't work as expected.