### PR TITLE
Removed the curly brackets that enclose the word 'data.table' in some post titles

### DIFF
--- a/posts/2023-10-15-intro_to_grant-toby_hocking/index.qmd
+++ b/posts/2023-10-15-intro_to_grant-toby_hocking/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Welcome to the {data.table} ecosystem project!"
+title: "Welcome to the data.table ecosystem project!"
 subtitle: "An NSF-POSE funded venture."
 author: "Toby Hocking"
 date: "2023-10-15"

--- a/posts/2024-02-18-dt_particularities-toby_hocking/index.qmd
+++ b/posts/2024-02-18-dt_particularities-toby_hocking/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Column assignment and reference semantics in {data.table}"
+title: "Column assignment and reference semantics in data.table"
 author: "Toby Hocking"
 date: "2024-02-18"
 categories: [tips, tutorials, developer]

--- a/posts/2024-03-06-interviews-anirban_chetia/index.qmd
+++ b/posts/2024-03-06-interviews-anirban_chetia/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Community interviews about {data.table}"
+title: "Community interviews about data.table"
 author: "Anirban Chetia"
 date: "2024-03-06"
 categories: [community, grant]


### PR DESCRIPTION
Not sure why they were introduced (and for these posts in particular) or if they are not being rendered correctly, but it looks odd (if the purpose was code-block style formatting, using backticks would work instead)