### PR TITLE
Remove the listings at the end of blog posts

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -30,15 +30,6 @@ format:
 
 editor: visual
 
-listing:
-  contents: ../../posts/*/*.qmd
-  categories: true
-  sort: "date desc"
-  type: default
-  feed: true
-  sort-ui: false
-  filter-ui: false
-  
 execute: 
   freeze: auto
 


### PR DESCRIPTION
This removes the listings at the end of every blog post. Tested with quarto-1.5.57. See also: #40, https://github.com/rdatatable-community/The-Raft/pull/70#issuecomment-2646010673

Before:
![listings-before](https://github.com/user-attachments/assets/54e312be-e24d-4604-b45a-120d39d6e892)

After:
![listings-after](https://github.com/user-attachments/assets/d8c1ad21-a896-4246-b92b-8e9ed0e81f63)

Or do you need the category links in the blog posts?